### PR TITLE
Launch `tool_script.py` via the main entrypoint script

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4,6 +4,8 @@
 
 import argparse
 import logging
+import sys
+from importlib import import_module
 from pathlib import Path
 
 import uvicorn
@@ -18,7 +20,6 @@ APP_AUTHOR = "OHTAP"
 
 PORT = 8001
 SPA_PATH = Path(__file__).parent.absolute() / "winnow" / "www-data"
-TOOL_SCRIPT_PATH = Path(__file__).parent.absolute() / "winnow" / "tool_script.py"
 DEV_STORAGE_PATH = Path(__file__).parent.absolute()
 
 log_config = {
@@ -41,8 +42,12 @@ log_config = {
 logging.config.dictConfig(log_config)
 
 
+def is_bundled():
+    return getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS")
+
+
 def dev():
-    return create_app(SPA_PATH, TOOL_SCRIPT_PATH, DEV_STORAGE_PATH, debug=True)
+    return create_app(SPA_PATH, DEV_STORAGE_PATH, is_bundled(), debug=True)
 
 
 def main():
@@ -57,7 +62,26 @@ def main():
         help="Launch application in development mode",
     )
 
+    parser.add_argument(
+        "--tool-script",
+        action="store",
+        default=False,
+        help="Execute Winnow's tool_script.py and pass it the provided JSON payload",
+    )
+
     args = parser.parse_args()
+
+    if args.tool_script:
+        # Flush the sys.stdout buffer on newlines
+        #  (a suitable alternative here for PYTHONUNBUFFERED or `-u` etc.)
+        sys.stdout.reconfigure(line_buffering=True)
+
+        # tool_script.py looks for its configuration at `sys.argv[1]`, so we need
+        #  to rewrite sys.argv here
+        sys.argv = [sys.executable, args.tool_script]
+
+        import_module(".tool_script", "winnow").main()
+        raise SystemExit
 
     logger = logging.getLogger("logger")
 
@@ -83,7 +107,7 @@ def main():
     logger.info(f"Starting application on https://localhost:{PORT}")
     logger.info(f"App storage path: {storage_path}")
 
-    app = create_app(SPA_PATH, TOOL_SCRIPT_PATH, storage_path)
+    app = create_app(SPA_PATH, storage_path, is_bundled())
 
     uvicorn.run(app, port=PORT, log_level="warning")
 


### PR DESCRIPTION
When bundled using `pyinstaller`, a native python interpreter isn't available, so `tool_script.py` can't be launched using
```python
tool_script_process = await asyncio.create_subprocess_exec(
    sys.executable,
    "-u",
    tool_script_path,
    json.dumps(run_data),
    stdout=asyncio.subprocess.PIPE,
    cwd=storage_path,
)
```

Instead, this PR configures the main entrypoint script (`cli.py`) to accept a `--tool-script` argument which takes the JSON payload and executes the `tool_script.main()` in-process.  `cli.py` can then call itself asynchronously with this argument to hand-off the processing of the "run".

There are many ways these shenanigans could be arranged, but the main goal as been to avoid touching `tool_script.py` as much as possible, and this works nicely.